### PR TITLE
Improve code coverage

### DIFF
--- a/src/QRMumps.jl
+++ b/src/QRMumps.jl
@@ -215,14 +215,13 @@ This subroutine performs a matrix-vector product of the type y = αAx + βy or y
 function qrm_spmat_mv! end
 
 @doc raw"""
-    qrm_spmat_nrm(spmat, nrm; ntype='f')
+    qrm_spmat_nrm(spmat; ntype='f')
 
 This routine computes the one-norm ``\|A\|_1``, the infinity-norm ``\|x\|_{\infty}`` or the two-norm ``\|x\|_2`` of a matrix.
 
 #### Input Arguments :
 
 * `spmat`: the input matrix.
-* `nrm`: the computed norm.
 * `ntype`: the type of norm to be computed. It can be either `'i'`, `'1'` or `'f'` for the infinity, one and Frobenius norms, respectively.
 """
 function qrm_spmat_nrm end

--- a/src/wrapper/qr_mumps_api.jl
+++ b/src/wrapper/qr_mumps_api.jl
@@ -628,15 +628,15 @@ for (fname, lname, elty, subty) in (("sqrm_residual_norm_c", libsqrm, Float32   
             return nrm
         end
 
-        function qrm_residual_norm!(spmat :: qrm_spmat{$elty}, b :: Matrix{$elty}, x :: Matrix{$elty}, nrm :: Vector{$elty}; transp :: Char='n')
+        function qrm_residual_norm!(spmat :: qrm_spmat{$elty}, b :: Matrix{$elty}, x :: Matrix{$elty}, nrm :: Vector{$subty}; transp :: Char='n')
             nrhs = size(x, 2)
             err = ccall(($fname, $lname), Cint, (Ref{c_spmat{$elty}}, Ptr{$elty}, Ptr{$elty}, Cint, Ptr{$subty}, UInt8), spmat, b, x, nrhs, nrm, transp)
             (err ≠ 0) && throw(ErrorException(error_handling(err)))
             return nothing
         end
 
-        @inline qrm_residual_norm!(spmat :: Transpose{$elty,qrm_spmat{$elty}}, b :: Matrix{$elty}, x :: Matrix{$elty}, nrm :: Vector{$elty}) = qrm_residual_norm!(spmat.parent, b, x, transp='t')
-        @inline qrm_residual_norm!(spmat :: Adjoint{$elty,qrm_spmat{$elty}}  , b :: Matrix{$elty}, x :: Matrix{$elty}, nrm :: Vector{$elty}) = qrm_residual_norm!(spmat.parent, b, x, transp='c')
+        @inline qrm_residual_norm!(spmat :: Transpose{$elty,qrm_spmat{$elty}}, b :: Matrix{$elty}, x :: Matrix{$elty}, nrm :: Vector{$subty}) = qrm_residual_norm!(spmat.parent, b, x, transp='t')
+        @inline qrm_residual_norm!(spmat :: Adjoint{$elty,qrm_spmat{$elty}}  , b :: Matrix{$elty}, x :: Matrix{$elty}, nrm :: Vector{$subty}) = qrm_residual_norm!(spmat.parent, b, x, transp='c')
 
         @inline qrm_residual_norm(spmat  :: Transpose{$elty,qrm_spmat{$elty}}, b :: Vector{$elty}, x :: Vector{$elty}) = qrm_residual_norm(spmat.parent, b, x, transp='t')
         @inline qrm_residual_norm(spmat  :: Transpose{$elty,qrm_spmat{$elty}}, b :: Matrix{$elty}, x :: Matrix{$elty}) = qrm_residual_norm(spmat.parent, b, x, transp='t')
@@ -669,22 +669,21 @@ for (fname, lname, elty, subty) in (("sqrm_residual_orth_c", libsqrm, Float32   
             return nrm
         end
 
-        function qrm_residual_orth!(spmat :: qrm_spmat{$elty}, r :: Matrix{$elty}, nrm :: Vector{$elty}; transp :: Char='n')
+        function qrm_residual_orth!(spmat :: qrm_spmat{$elty}, r :: Matrix{$elty}, nrm :: Vector{$subty}; transp :: Char='n')
             nrhs = size(r, 2)
             err = ccall(($fname, $lname), Cint, (Ref{c_spmat{$elty}}, Ptr{$elty}, Cint, Ptr{$subty}, UInt8), spmat, r, nrhs, nrm, transp)
             (err ≠ 0) && throw(ErrorException(error_handling(err)))
             return nothing
         end
 
-        @inline qrm_residual_orth!(spmat :: Transpose{$elty,qrm_spmat{$elty}}, r :: Matrix{$elty}, nrm :: Vector{$elty}) = qrm_residual_orth!(spmat.parent, r, transp='t')
-        @inline qrm_residual_orth!(spmat :: Adjoint{$elty,qrm_spmat{$elty}}  , r :: Matrix{$elty}, nrm :: Vector{$elty}) = qrm_residual_orth!(spmat.parent, r, transp='c')
+        @inline qrm_residual_orth!(spmat :: Transpose{$elty,qrm_spmat{$elty}}, r :: Matrix{$elty}, nrm :: Vector{$subty}) = qrm_residual_orth!(spmat.parent, r, transp='t')
+        @inline qrm_residual_orth!(spmat :: Adjoint{$elty,qrm_spmat{$elty}}  , r :: Matrix{$elty}, nrm :: Vector{$subty}) = qrm_residual_orth!(spmat.parent, r, transp='c')
 
         @inline qrm_residual_orth(spmat  :: Transpose{$elty,qrm_spmat{$elty}}, r :: Vector{$elty}) = qrm_residual_orth(spmat.parent, r, transp='t')
         @inline qrm_residual_orth(spmat  :: Transpose{$elty,qrm_spmat{$elty}}, r :: Matrix{$elty}) = qrm_residual_orth(spmat.parent, r, transp='t')
 
         @inline qrm_residual_orth(spmat  :: Adjoint{$elty,qrm_spmat{$elty}}  , r :: Vector{$elty}) = qrm_residual_orth(spmat.parent, r, transp='c')
         @inline qrm_residual_orth(spmat  :: Adjoint{$elty,qrm_spmat{$elty}}  , r :: Matrix{$elty}) = qrm_residual_orth(spmat.parent, r, transp='c')
-
     end
 end
 

--- a/src/wrapper/qr_mumps_common.jl
+++ b/src/wrapper/qr_mumps_common.jl
@@ -100,7 +100,7 @@ end
 
 const GICNTL = ("qrm_eunit", "qrm_print_etree", "qrm_ounit", "qrm_dunit", "qrm_ncpu", "qrm_ngpu", "qrm_max_mem", "qrm_tot_mem")
 const PICNTL = ("qrm_ordering", "qrm_minamalg", "qrm_mb", "qrm_nb", "qrm_ib", "qrm_bh", "qrm_keeph", "qrm_rhsnb", "qrm_nlz", "qrm_pinth")
-const RCNTL  = ("qrm_amalgth", "qrm_rweigth", "qrm_mem_relax", "qrm_rd_eps")
+const RCNTL  = ("qrm_amalgth", "qrm_mem_relax", "qrm_rd_eps")
 const STATS  = ("qrm_e_nnz_r", "qrm_e_nnz_h", "qrm_e_facto_flops", "qrm_e_facto_mempeak", "qrm_nnz_r", "qrm_nnz_h", "qrm_facto_flops", "qrm_rd_num")
 
 function error_handling(err :: Cint)

--- a/test/test_qrm.jl
+++ b/test/test_qrm.jl
@@ -425,4 +425,64 @@ end
   end
 end
 
+@testset "Auxiliary functions" begin
+  for str ∈ QRMumps.GICNTL ∪ QRMumps.PICNTL ∪ QRMumps.RCNTL
+    qrm_get(str)
+    qrm_set(str, 1)
+  end
+
+  for T in (Float32, Float64, ComplexF32, ComplexF64)
+    transp = (T <: Real) ? 't' : 'c'
+    A = sprand(T, n, n, 0.3)
+    spmat = qrm_spmat_init(A)
+    spfct = qrm_analyse(spmat)
+    qrm_factorize!(spmat, spfct)
+
+    for str ∈ QRMumps.PICNTL ∪ QRMumps.RCNTL
+      qrm_get(spfct, str)
+      qrm_set(spfct, str, 1)
+    end
+
+    for str ∈ QRMumps.STATS
+      qrm_get(spfct, str)
+    end
+
+    A = 2 * A
+    qrm_update!(spmat, A)
+
+    for ntype ∈ ('i', '1', 'f')
+      qrm_spmat_nrm(spmat, ntype=ntype)
+    end
+
+    for ntype ∈ ('i', '1', '2')
+      x = rand(T, 10)
+      qrm_vecnrm(x, ntype=ntype)
+
+      X = rand(T, 10, 5)
+      nrm = qrm_vecnrm(X, ntype=ntype)
+
+      X = 2 * X
+      qrm_vecnrm!(X, nrm, ntype=ntype)
+    end
+
+    b = rand(T, n)
+    x = rand(T, n)
+    r = b - A * x
+    qrm_residual_orth(spmat, r)
+    qrm_residual_orth(spmat, r, transp=transp)
+    qrm_residual_norm(spmat, b, x)
+    qrm_residual_norm(spmat, b, x, transp=transp)
+
+    B = rand(T, n, 5)
+    X = rand(T, n, 5)
+    R = B - A * X
+    nrm = qrm_residual_orth(spmat, R)
+    qrm_residual_orth!(spmat, R, nrm)
+    qrm_residual_orth(spmat, R, transp=transp)
+    nrm = qrm_residual_norm(spmat, B, X)
+    qrm_residual_norm!(spmat, B, X, nrm)
+    qrm_residual_norm(spmat, B, X, transp=transp)
+  end
+end
+
 qrm_finalize()


### PR DESCRIPTION
@abuttari 
- Le paramètre `qrm_rweight` n'existe pas lorsque j'essaye de récupérer sa valeur avec `qrm_set` ou de modifier sa valeur avec `qrm_get`. Je l'ai supprimé de la variable `RCNTL`;
- Les paramètres `qrm_ncpu` et `qrm_ngpu` sont toujours égaux à 0 lorsque j'utilise `qrm_get` et si je change leur valeur avec `qrm_set` ce n'est pas pris en compte.