### PR TITLE
Update the docstring of qrm_spmat

### DIFF
--- a/src/wrapper/qr_mumps_common.jl
+++ b/src/wrapper/qr_mumps_common.jl
@@ -15,12 +15,12 @@ mutable struct c_spmat{T}
 end
 
 @doc raw"""
-This data type is used to store a sparse matrix in the COO (or coordinate) format through the irn, jcn
-and val fields containing the row indices, column indices and values, respectively and the m, n and nz
-containing the number of rows, columns and nonzeros, respectively. qr mumps uses a Fortran-style
+This data type is used to store a sparse matrix in the COO (or coordinate) format through the `irn`, `jcn`
+and `val` fields containing the row indices, column indices and values, respectively and the `m`, `n` and `nz`
+containing the number of rows, columns and nonzeros, respectively. qr\_mumps uses a Fortran-style
 1-based numbering and thus all row indices are expected to be between 1 and m and all the column
 indices between 1 and n. Duplicate entries are summed during the factorization, out-of-bound entries
-are ignored. The sym field is used to specify if the matrix is symmetric (> 0) or unsymmetric (= 0).
+are ignored. The `sym` field is used to specify if the matrix is symmetric and positive definite (`true`) or not (`false`).
 """
 mutable struct qrm_spmat{T} <: AbstractSparseMatrix{T, Cint}
   irn :: Vector{Cint}


### PR DESCRIPTION
@abuttari 
J'ai changé `qrm_spposv` en `qrm_cholesky`. je trouve que c'est plus explicite comme nom de fonction.
Tu en penses quoi ?

Est-ce qu'on ne devrait pas enlever le préfixe `qrm_` à l'ensemble des fonctions en Julia sinon en passant ?
