### PR TITLE
Add __init__() function

### DIFF
--- a/src/QRMumps.jl
+++ b/src/QRMumps.jl
@@ -12,8 +12,10 @@ if haskey(ENV, "JULIA_QR_MUMPS_LIBRARY_PATH")
   const libzqrm = joinpath(ENV["JULIA_QR_MUMPS_LIBRARY_PATH"], "libzqrm.$dlext")
   const libqrm_common = joinpath(ENV["JULIA_QR_MUMPS_LIBRARY_PATH"], "libqrm_common.$dlext")
 else
-  println("Yggdrasil Installation")
   using qr_mumps_jll
+  function __init__()
+    qrm_init()
+  end
 end
 
 include("wrapper/qr_mumps_common.jl")
@@ -41,6 +43,7 @@ export qrm_spmat, qrm_spfct,
     qrm_init(ncpu, ngpu)
 
 This routine initializes qr\_mumps and should be called prior to any other qr\_mumps routine.
+This function is automatically called if you use qr\_mumps precompiled with Yggdrasil.
 
     qrm_init()
 

--- a/test/test_qrm.jl
+++ b/test/test_qrm.jl
@@ -1,4 +1,3 @@
-qrm_init()
 m = 200
 n = 100
 p = 5
@@ -484,5 +483,3 @@ end
     qrm_residual_norm(spmat, B, X, transp=transp)
   end
 end
-
-qrm_finalize()


### PR DESCRIPTION
@abuttari 
I found a way to avoid the call of `qrm_init()` if we use the `qr_mumps` precompiled with Yggdrasil.

I tested `qr_mumps` precompiled with `StarPU` and it only works with Linux (#54).
I recompiled the sequential version with Yggdrasil and we should only provide this version for the moment with `QRMumps.jl`.


