### PR TITLE
add COO constructor and update method

### DIFF
--- a/src/QRMumps.jl
+++ b/src/QRMumps.jl
@@ -69,19 +69,31 @@ function qrm_finalize end
 
 @doc raw"""
     qrm_spmat_init!(spmat, A; sym=false)
+    spmat = qrm_spmat_init!(spmat, m, n, rows, cols, vals; sym=false)
 
 This routine initializes a **qrm_spmat** type data structure from a **sparseMatrixCSC**.
 
 #### Input Arguments :
 
+In the first form,
+
 * `spmat`: the **qrm_spmat** sparse matrix to be initialized.
 * `A` : a Julia sparse matrix stored in **SparseMatrixCSC** format.
 * `sym` : a boolean to specify if the matrix is symmetric / hermitian (true) or unsymmetric (false).
+
+In the second form, the matrix `A` is specified using
+
+* `m`: the number of rows.
+* `n`: the number of columns.
+* `rows`: the array of row indices of nonzero elements.
+* `cols`: the array of column indices of nonzero elements.
+* `vals`: the array of values of nonzero elements.
 """
 function qrm_spmat_init! end
 
 @doc raw"""
     spmat = qrm_spmat_init(A; sym=false)
+    spmat = qrm_spmat_init(m, n, rows, cols, vals; sym=false)
 """
 function qrm_spmat_init end
 
@@ -127,14 +139,21 @@ function qrm_spfct_destroy! end
 
 @doc raw"""
     qrm_update!(spmat, A)
+    qrm_update!(spmat, vals)
 
 This routine updates a **qrm_spmat** type data structure from a **sparseMatrixCSC**.
 `spmat` and `A` must have the same sparsity pattern.
 
 #### Input Arguments :
 
+In the first form,
+
 * `spmat`: the **qrm_spmat** sparse matrix to be updated.
 * `A` : a Julia sparse matrix stored in **SparseMatrixCSC** format.
+
+In the second form,
+
+* `vals`: the array of values of nonzero elements of `A`.
 """
 function qrm_update! end
 


### PR DESCRIPTION
The diff makes the change look more complicated than it is. I haven't added SparseMatricesCOO as a dependency; perhaps it's not necessary.

The reason why there are two integer parameters `J` and `I` is that `size(A)` apparently always return `Int64`s, whereas `findnz(A)` return integer arrays of type defined by `A`.