### PR TITLE
Update QRMumps.jl for the release 3.1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,18 +6,19 @@ version = "0.2.4"
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+OpenBLAS32_jll = "656ef2d0-ae68-5445-9ca0-591084a874a2"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 qr_mumps_jll = "e37b5aa0-c611-5f0f-83fb-aee446c0b77e"
 
 [compat]
-julia = "1.6"
 Libdl = "1.6"
 LinearAlgebra = "1.6"
 Printf = "1.6"
-SparseArrays = "1.6"
 Random = "1.6"
+SparseArrays = "1.6"
 Test = "1.6"
+julia = "1.6"
 qr_mumps_jll = "3.0.4"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ qr_mumps_jll = "e37b5aa0-c611-5f0f-83fb-aee446c0b77e"
 [compat]
 Libdl = "1.6"
 LinearAlgebra = "1.6"
+OpenBLAS32_jll = "0.3.10"
 Printf = "1.6"
 Random = "1.6"
 SparseArrays = "1.6"

--- a/gen/README.md
+++ b/gen/README.md
@@ -7,4 +7,3 @@ This is done using Clang.jl.
 
 Either run `julia wrapper.jl` directly, or include it and call the `main()` function.
 Be sure to activate the project environment in this folder (`julia --project`), which will install `Clang.jl` and `JuliaFormatter.jl`.
-The `main` function supports the boolean keyword argument `optimized` to clear the generated wrappers.

--- a/gen/wrapper.jl
+++ b/gen/wrapper.jl
@@ -28,7 +28,7 @@ function main()
     spmat = "spmat" * pattern
     code = replace(code, qrm_spmat_c => spmat)
 
-    qrm_spfct_c = "qrm_sptct_c" * pattern
+    qrm_spfct_c = "qrm_spfct_c" * pattern
     spfct = "spfct" * pattern
     code = replace(code, qrm_spfct_c => spfct)
   end

--- a/src/QRMumps.jl
+++ b/src/QRMumps.jl
@@ -6,7 +6,6 @@ import Base: \
 import LinearAlgebra: mul!
 
 if haskey(ENV, "JULIA_QRMUMPS_LIBRARY_PATH")
-  @info("Custom Installation")
   const libsqrm = joinpath(ENV["JULIA_QRMUMPS_LIBRARY_PATH"], "libsqrm.$dlext")
   const libdqrm = joinpath(ENV["JULIA_QRMUMPS_LIBRARY_PATH"], "libdqrm.$dlext")
   const libcqrm = joinpath(ENV["JULIA_QRMUMPS_LIBRARY_PATH"], "libcqrm.$dlext")
@@ -14,10 +13,20 @@ if haskey(ENV, "JULIA_QRMUMPS_LIBRARY_PATH")
   const libqrm_common = joinpath(ENV["JULIA_QRMUMPS_LIBRARY_PATH"], "libqrm_common.$dlext")
   const QRMUMPS_INSTALLATION = "CUSTOM"
 else
+  using OpenBLAS32_jll
   using qr_mumps_jll
   const QRMUMPS_INSTALLATION = "YGGDRASIL"
-  function __init__()
+end
+
+function __init__()
+  if QRMUMPS_INSTALLATION == "YGGDRASIL"
     qrm_init()
+    if VERSION ≥ v"1.10"
+      config = LinearAlgebra.BLAS.lbt_get_config()
+      if !any(lib -> lib.interface == :lp64, config.loaded_libs)
+        LinearAlgebra.BLAS.lbt_forward(OpenBLAS32_jll.libopenblas_path)
+      end
+    end
   end
 end
 

--- a/src/wrapper/libqrmumps.jl
+++ b/src/wrapper/libqrmumps.jl
@@ -20,9 +20,25 @@ function sqrm_analyse_c(spmat, spfct, transp)
                                   spfct::Ref{c_spfct{Float32}}, transp::Cchar)::Cint
 end
 
+struct qrm_dscr_type_c
+    h::Ptr{Cvoid}
+end
+
+function sqrm_analyse_async_c(qrm_dscr_c, spmat, spfct, transp)
+    @ccall libsqrm.sqrm_analyse_async_c(qrm_dscr_c::Ptr{qrm_dscr_type_c},
+                                        spmat::Ref{c_spmat{Float32}},
+                                        spfct::Ref{c_spfct{Float32}}, transp::Cchar)::Cint
+end
+
 function sqrm_factorize_c(spmat, spfct, transp)
     @ccall libsqrm.sqrm_factorize_c(spmat::Ref{c_spmat{Float32}},
                                     spfct::Ref{c_spfct{Float32}}, transp::Cchar)::Cint
+end
+
+function sqrm_factorize_async_c(qrm_dscr_c, spmat, spfct, transp)
+    @ccall libsqrm.sqrm_factorize_async_c(qrm_dscr_c::Ptr{qrm_dscr_type_c},
+                                          spmat::Ref{c_spmat{Float32}},
+                                          spfct::Ref{c_spfct{Float32}}, transp::Cchar)::Cint
 end
 
 function sqrm_solve_c(spfct, transp, b, x, nrhs)
@@ -33,6 +49,11 @@ end
 function sqrm_apply_c(spfct, transp, b, nrhs)
     @ccall libsqrm.sqrm_apply_c(spfct::Ref{c_spfct{Float32}}, transp::Cchar, b::Ptr{Cfloat},
                                 nrhs::Cint)::Cint
+end
+
+function sqrm_spfct_unmqr_c(spfct, transp, b, nrhs)
+    @ccall libsqrm.sqrm_spfct_unmqr_c(spfct::Ref{c_spfct{Float32}}, transp::Cchar,
+                                      b::Ptr{Cfloat}, nrhs::Cint)::Cint
 end
 
 function sqrm_spmat_mv_c(spmat, transp, alpha, x, beta, y, nrhs)
@@ -127,6 +148,11 @@ function sqrm_spfct_get_schur_c(spfct, s, i, j, m, n)
                                           i::Cint, j::Cint, m::Cint, n::Cint)::Cint
 end
 
+function sqrm_spfct_get_schur_async_c(spfct, hdls)
+    @ccall libsqrm.sqrm_spfct_get_schur_async_c(spfct::Ref{c_spfct{Float32}},
+                                                hdls::Ptr{Ptr{Cvoid}})::Cint
+end
+
 function sqrm_spfct_get_r_c(spfct, spmat)
     @ccall libsqrm.sqrm_spfct_get_r_c(spfct::Ref{c_spfct{Float32}},
                                       spmat::Ref{c_spmat{Float32}})::Cint
@@ -164,9 +190,21 @@ function dqrm_analyse_c(spmat, spfct, transp)
                                   spfct::Ref{c_spfct{Float64}}, transp::Cchar)::Cint
 end
 
+function dqrm_analyse_async_c(qrm_dscr_c, spmat, spfct, transp)
+    @ccall libdqrm.dqrm_analyse_async_c(qrm_dscr_c::Ptr{qrm_dscr_type_c},
+                                        spmat::Ref{c_spmat{Float64}},
+                                        spfct::Ref{c_spfct{Float64}}, transp::Cchar)::Cint
+end
+
 function dqrm_factorize_c(spmat, spfct, transp)
     @ccall libdqrm.dqrm_factorize_c(spmat::Ref{c_spmat{Float64}},
                                     spfct::Ref{c_spfct{Float64}}, transp::Cchar)::Cint
+end
+
+function dqrm_factorize_async_c(qrm_dscr_c, spmat, spfct, transp)
+    @ccall libdqrm.dqrm_factorize_async_c(qrm_dscr_c::Ptr{qrm_dscr_type_c},
+                                          spmat::Ref{c_spmat{Float64}},
+                                          spfct::Ref{c_spfct{Float64}}, transp::Cchar)::Cint
 end
 
 function dqrm_solve_c(spfct, transp, b, x, nrhs)
@@ -177,6 +215,11 @@ end
 function dqrm_apply_c(spfct, transp, b, nrhs)
     @ccall libdqrm.dqrm_apply_c(spfct::Ref{c_spfct{Float64}}, transp::Cchar,
                                 b::Ptr{Cdouble}, nrhs::Cint)::Cint
+end
+
+function dqrm_spfct_unmqr_c(spfct, transp, b, nrhs)
+    @ccall libdqrm.dqrm_spfct_unmqr_c(spfct::Ref{c_spfct{Float64}}, transp::Cchar,
+                                      b::Ptr{Cdouble}, nrhs::Cint)::Cint
 end
 
 function dqrm_spmat_mv_c(spmat, transp, alpha, x, beta, y, nrhs)
@@ -271,6 +314,11 @@ function dqrm_spfct_get_schur_c(spfct, s, i, j, m, n)
                                           i::Cint, j::Cint, m::Cint, n::Cint)::Cint
 end
 
+function dqrm_spfct_get_schur_async_c(spfct, hdls)
+    @ccall libdqrm.dqrm_spfct_get_schur_async_c(spfct::Ref{c_spfct{Float64}},
+                                                hdls::Ptr{Ptr{Cvoid}})::Cint
+end
+
 function dqrm_spfct_get_r_c(spfct, spmat)
     @ccall libdqrm.dqrm_spfct_get_r_c(spfct::Ref{c_spfct{Float64}},
                                       spmat::Ref{c_spmat{Float64}})::Cint
@@ -308,9 +356,23 @@ function cqrm_analyse_c(spmat, spfct, transp)
                                   spfct::Ref{c_spfct{ComplexF32}}, transp::Cchar)::Cint
 end
 
+function cqrm_analyse_async_c(qrm_dscr_c, spmat, spfct, transp)
+    @ccall libcqrm.cqrm_analyse_async_c(qrm_dscr_c::Ptr{qrm_dscr_type_c},
+                                        spmat::Ref{c_spmat{ComplexF32}},
+                                        spfct::Ref{c_spfct{ComplexF32}},
+                                        transp::Cchar)::Cint
+end
+
 function cqrm_factorize_c(spmat, spfct, transp)
     @ccall libcqrm.cqrm_factorize_c(spmat::Ref{c_spmat{ComplexF32}},
                                     spfct::Ref{c_spfct{ComplexF32}}, transp::Cchar)::Cint
+end
+
+function cqrm_factorize_async_c(qrm_dscr_c, spmat, spfct, transp)
+    @ccall libcqrm.cqrm_factorize_async_c(qrm_dscr_c::Ptr{qrm_dscr_type_c},
+                                          spmat::Ref{c_spmat{ComplexF32}},
+                                          spfct::Ref{c_spfct{ComplexF32}},
+                                          transp::Cchar)::Cint
 end
 
 function cqrm_solve_c(spfct, transp, b, x, nrhs)
@@ -321,6 +383,11 @@ end
 function cqrm_apply_c(spfct, transp, b, nrhs)
     @ccall libcqrm.cqrm_apply_c(spfct::Ref{c_spfct{ComplexF32}}, transp::Cchar,
                                 b::Ptr{ComplexF32}, nrhs::Cint)::Cint
+end
+
+function cqrm_spfct_unmqr_c(spfct, transp, b, nrhs)
+    @ccall libcqrm.cqrm_spfct_unmqr_c(spfct::Ref{c_spfct{ComplexF32}}, transp::Cchar,
+                                      b::Ptr{ComplexF32}, nrhs::Cint)::Cint
 end
 
 function cqrm_spmat_mv_c(spmat, transp, alpha, x, beta, y, nrhs)
@@ -418,6 +485,11 @@ function cqrm_spfct_get_schur_c(spfct, s, i, j, m, n)
                                           n::Cint)::Cint
 end
 
+function cqrm_spfct_get_schur_async_c(spfct, hdls)
+    @ccall libcqrm.cqrm_spfct_get_schur_async_c(spfct::Ref{c_spfct{ComplexF32}},
+                                                hdls::Ptr{Ptr{Cvoid}})::Cint
+end
+
 function cqrm_spfct_get_r_c(spfct, spmat)
     @ccall libcqrm.cqrm_spfct_get_r_c(spfct::Ref{c_spfct{ComplexF32}},
                                       spmat::Ref{c_spmat{ComplexF32}})::Cint
@@ -455,9 +527,23 @@ function zqrm_analyse_c(spmat, spfct, transp)
                                   spfct::Ref{c_spfct{ComplexF64}}, transp::Cchar)::Cint
 end
 
+function zqrm_analyse_async_c(qrm_dscr_c, spmat, spfct, transp)
+    @ccall libzqrm.zqrm_analyse_async_c(qrm_dscr_c::Ptr{qrm_dscr_type_c},
+                                        spmat::Ref{c_spmat{ComplexF64}},
+                                        spfct::Ref{c_spfct{ComplexF64}},
+                                        transp::Cchar)::Cint
+end
+
 function zqrm_factorize_c(spmat, spfct, transp)
     @ccall libzqrm.zqrm_factorize_c(spmat::Ref{c_spmat{ComplexF64}},
                                     spfct::Ref{c_spfct{ComplexF64}}, transp::Cchar)::Cint
+end
+
+function zqrm_factorize_async_c(qrm_dscr_c, spmat, spfct, transp)
+    @ccall libzqrm.zqrm_factorize_async_c(qrm_dscr_c::Ptr{qrm_dscr_type_c},
+                                          spmat::Ref{c_spmat{ComplexF64}},
+                                          spfct::Ref{c_spfct{ComplexF64}},
+                                          transp::Cchar)::Cint
 end
 
 function zqrm_solve_c(spfct, transp, b, x, nrhs)
@@ -468,6 +554,11 @@ end
 function zqrm_apply_c(spfct, transp, b, nrhs)
     @ccall libzqrm.zqrm_apply_c(spfct::Ref{c_spfct{ComplexF64}}, transp::Cchar,
                                 b::Ptr{ComplexF64}, nrhs::Cint)::Cint
+end
+
+function zqrm_spfct_unmqr_c(spfct, transp, b, nrhs)
+    @ccall libzqrm.zqrm_spfct_unmqr_c(spfct::Ref{c_spfct{ComplexF64}}, transp::Cchar,
+                                      b::Ptr{ComplexF64}, nrhs::Cint)::Cint
 end
 
 function zqrm_spmat_mv_c(spmat, transp, alpha, x, beta, y, nrhs)
@@ -565,6 +656,11 @@ function zqrm_spfct_get_schur_c(spfct, s, i, j, m, n)
                                           n::Cint)::Cint
 end
 
+function zqrm_spfct_get_schur_async_c(spfct, hdls)
+    @ccall libzqrm.zqrm_spfct_get_schur_async_c(spfct::Ref{c_spfct{ComplexF64}},
+                                                hdls::Ptr{Ptr{Cvoid}})::Cint
+end
+
 function zqrm_spfct_get_r_c(spfct, spmat)
     @ccall libzqrm.zqrm_spfct_get_r_c(spfct::Ref{c_spfct{ComplexF64}},
                                       spmat::Ref{c_spmat{ComplexF64}})::Cint
@@ -610,4 +706,20 @@ end
 
 function qrm_finalize_c()
     @ccall libqrm_common.qrm_finalize_c()::Cvoid
+end
+
+function qrm_dscr_init_c(qrm_dscr_c)
+    @ccall libqrm_common.qrm_dscr_init_c(qrm_dscr_c::Ptr{qrm_dscr_type_c})::Cint
+end
+
+function qrm_dscr_destroy_c(qrm_dscr_c)
+    @ccall libqrm_common.qrm_dscr_destroy_c(qrm_dscr_c::Ptr{qrm_dscr_type_c})::Cint
+end
+
+function qrm_barrier_c()
+    @ccall libqrm_common.qrm_barrier_c()::Cint
+end
+
+function qrm_barrier_dscr_c(qrm_dscr_c)
+    @ccall libqrm_common.qrm_barrier_dscr_c(qrm_dscr_c::Ptr{qrm_dscr_type_c})::Cint
 end


### PR DESCRIPTION
@abuttari 
What is the goal of the new structure `qrm_dscr_type_c`?
Thanks for the implementation of `Xqrm_spfct_unmqr_c` :+1: 

We have an issue with the finalizer on FreeBSD and Mac M1 with the release 3.1.0:
https://cirrus-ci.com/task/5077245763518464?logs=test#L399

It seems the return status is `1` when we call `qrm_spmat_finalize` .