### PR TITLE
Preallocate references to values for qrm_get in qrm_spfct

### DIFF
--- a/src/wrapper/qr_mumps_api.jl
+++ b/src/wrapper/qr_mumps_api.jl
@@ -861,15 +861,16 @@ for (finame, frname, elty) in ((:sqrm_spfct_get_i8_c, :sqrm_spfct_get_r4_c, :Flo
     @eval begin
         function qrm_get(spfct :: qrm_spfct{$elty}, str :: String)
             if (str ∈ PICNTL) || (str ∈ STATS)
-                err = $finame(spfct, str, spfct.get_val_long)
+                val = spfct.ref_int
+                err = $finame(spfct, str, val)
             elseif str ∈ RCNTL
-                err = $frname(spfct, str, spfct.get_val_float)
+                val = spfct.ref_float
+                err = $frname(spfct, str, val)
             else
                 err = Int32(23)
             end
             qrm_check(err)
-            (str ∈ RCNTL) && return spfct.get_val_float[]
-            return spfct.get_val_long[]
+            return val[]
         end
     end
 end

--- a/src/wrapper/qr_mumps_api.jl
+++ b/src/wrapper/qr_mumps_api.jl
@@ -861,16 +861,15 @@ for (finame, frname, elty) in ((:sqrm_spfct_get_i8_c, :sqrm_spfct_get_r4_c, :Flo
     @eval begin
         function qrm_get(spfct :: qrm_spfct{$elty}, str :: String)
             if (str ∈ PICNTL) || (str ∈ STATS)
-                val = Ref{Clonglong}(0)
-                err = $finame(spfct, str, val)
+                err = $finame(spfct, str, spfct.get_val_long)
             elseif str ∈ RCNTL
-                val = Ref{Float32}(0)
-                err = $frname(spfct, str, val)
+                err = $frname(spfct, str, spfct.get_val_float)
             else
                 err = Int32(23)
             end
             qrm_check(err)
-            return val[]
+            (str ∈ RCNTL) && return spfct.get_val_float[]
+            return spfct.get_val_long[]
         end
     end
 end

--- a/src/wrapper/qr_mumps_common.jl
+++ b/src/wrapper/qr_mumps_common.jl
@@ -75,13 +75,15 @@ the factorization, namely, the factors with all the symbolic information needed 
 solve phase.
 """
 mutable struct qrm_spfct{T} <: Factorization{T}
-  cperm_in :: Vector{Cint}
-  ptr_rp   :: Ref{Ptr{Cint}}
-  ptr_cp   :: Ref{Ptr{Cint}}
-  fct      :: c_spfct{T}
+  cperm_in      :: Vector{Cint}
+  ptr_rp        :: Ref{Ptr{Cint}}
+  ptr_cp        :: Ref{Ptr{Cint}}
+  get_val_long  :: Ref{Clonglong}
+  get_val_float :: Ref{Float32}
+  fct           :: c_spfct{T}
 
   function qrm_spfct{T}() where T
-    spfct = new(Cint[], Ref{Ptr{Cint}}(), Ref{Ptr{Cint}}(), c_spfct{T}())
+    spfct = new(Cint[], Ref{Ptr{Cint}}(), Ref{Ptr{Cint}}(), Ref{Clonglong}(0), Ref{Float32}(0), c_spfct{T}())
     finalizer(qrm_spfct_destroy!, spfct)
     return spfct
   end

--- a/src/wrapper/qr_mumps_common.jl
+++ b/src/wrapper/qr_mumps_common.jl
@@ -75,12 +75,12 @@ the factorization, namely, the factors with all the symbolic information needed 
 solve phase.
 """
 mutable struct qrm_spfct{T} <: Factorization{T}
-  cperm_in      :: Vector{Cint}
-  ptr_rp        :: Ref{Ptr{Cint}}
-  ptr_cp        :: Ref{Ptr{Cint}}
-  get_val_long  :: Ref{Clonglong}
-  get_val_float :: Ref{Float32}
-  fct           :: c_spfct{T}
+  cperm_in :: Vector{Cint}
+  ptr_rp   :: Ref{Ptr{Cint}}
+  ptr_cp   :: Ref{Ptr{Cint}}
+  ref_int  :: Ref{Clonglong}
+  ref_float:: Ref{Float32}
+  fct      :: c_spfct{T}
 
   function qrm_spfct{T}() where T
     spfct = new(Cint[], Ref{Ptr{Cint}}(), Ref{Ptr{Cint}}(), Ref{Clonglong}(0), Ref{Float32}(0), c_spfct{T}())

--- a/test/test_qrm.jl
+++ b/test/test_qrm.jl
@@ -546,3 +546,27 @@ end
     @test norm(b - A'*(A*x)) ≥ norm(b - A'*(A*x_refined))
   end
 end
+
+@testset "allocations" begin
+  for T in (Float32, Float64, ComplexF32, ComplexF64)
+    tol = (real(T) == Float32) ? 1e-3 : 1e-12
+    transp = (T <: Real) ? 't' : 'c'
+
+    for I in (Int32 , Int64)
+      A = sprand(T, m, n, 0.3)
+      A = convert(SparseMatrixCSC{T,I}, A)
+
+      spmat = qrm_spmat_init(T)
+      qrm_spmat_init!(spmat, A)
+
+      spfct = qrm_spfct_init(spmat)
+
+      qrm_set(spfct, "qrm_rd_eps", tol)
+      qrm_analyse!(spmat, spfct)
+      qrm_factorize!(spmat, spfct)
+      @test (@allocated qrm_get(spfct, "qrm_rd_num")) == 0
+      
+    end
+  end
+
+end


### PR DESCRIPTION
@amontoison In the same spirit as #113, I will eventually need this if I end up using qrm_get as suggested in #114.